### PR TITLE
Adjust ProductElementInterface

### DIFF
--- a/src/Elements/ProductElementInterface.php
+++ b/src/Elements/ProductElementInterface.php
@@ -32,4 +32,6 @@ interface ProductElementInterface extends ElementInterface
     public function addISBN(string $isbn): ProductElementInterface;
 
     public function addCustomAttribute(string $attributeId, $value): ProductElementInterface;
+
+    public function addCustomElement(string $key, string $value): ProductElementInterface;
 }


### PR DESCRIPTION
When I was using this package, I've notice that by not having this method in the interface, and the return type of the implementation is the interface, we lost the type hint inside some IDE's (like phpstorm)

