### PR TITLE
Standardised Tests Namespace

### DIFF
--- a/tests/Unit/Elements/BrandElementTest.php
+++ b/tests/Unit/Elements/BrandElementTest.php
@@ -1,5 +1,5 @@
 <?php
-namespace Tests\Feature;
+namespace Tests\Unit\Elements;
 
 use BazaarVoice\Elements\BrandElement;
 use PHPUnit\Framework\TestCase;

--- a/tests/Unit/Elements/CategoryElementTest.php
+++ b/tests/Unit/Elements/CategoryElementTest.php
@@ -1,5 +1,5 @@
 <?php
-namespace Tests\Feature;
+namespace Tests\Unit\Elements;
 
 use BazaarVoice\Elements\CategoryElement;
 use PHPUnit\Framework\TestCase;

--- a/tests/Unit/Interaction/FeedTest.php
+++ b/tests/Unit/Interaction/FeedTest.php
@@ -1,7 +1,8 @@
 <?php
-namespace BazaarVoice\Interaction;
+namespace Tests\Unit\Interaction;
 
 use BazaarVoice\Elements\InteractionElement;
+use BazaarVoice\Interaction\Feed;
 use PHPUnit\Framework\TestCase;
 
 class FeedTest extends TestCase

--- a/tests/Unit/Product/FeedTest.php
+++ b/tests/Unit/Product/FeedTest.php
@@ -1,10 +1,11 @@
 <?php
-namespace BazaarVoice\Product;
+namespace Tests\Unit\Product;
 
 use BazaarVoice\Elements\BrandElementInterface;
 use BazaarVoice\Elements\CategoryElement;
 use BazaarVoice\Elements\FeedElementInterface;
 use BazaarVoice\Elements\ProductElement;
+use BazaarVoice\Product\Feed;
 use Exception;
 use org\bovigo\vfs\vfsStream;
 use org\bovigo\vfs\vfsStreamDirectory;


### PR DESCRIPTION
I've notice that within all tests namespace, there's no pattern.
I choose to follow one, what doesn't make it the right choice, but at least it's all standardised now.