### PR TITLE
fix/avoid send empty files

### DIFF
--- a/src/AbstractFeed.php
+++ b/src/AbstractFeed.php
@@ -88,6 +88,10 @@ abstract class AbstractFeed implements FeedInterface
 
     public function sendFeed(string $filePath, string $sftpUsername, string $sftpPassword, string $sftpDirectory = 'import-inbox', string $sftpPort = '22'): bool
     {
+        if (filesize($filePath) === 0) {
+            throw new Exception('The file is empty.');
+        }
+
         $filename = basename($filePath);
 
         $sftp = new SFTP($this->getHost(), $sftpPort);

--- a/tests/Unit/Product/FeedTest.php
+++ b/tests/Unit/Product/FeedTest.php
@@ -135,4 +135,48 @@ class FeedTest extends TestCase
         // Assertions
         $this->assertTrue(vfsStreamWrapper::getRoot()->hasChild($testFeedFile . '.xml'));
     }
+
+    /** @test */
+    public function it_get_exception_trying_send_empty_files()
+    {
+        // Set
+        $testFeedFile = 'test-feed-file.txt';
+
+        vfsStreamWrapper::register();
+        vfsStreamWrapper::setRoot(new vfsStreamDirectory('root_dir'));
+        vfsStream::newFile($testFeedFile)->at(vfsStreamWrapper::getRoot());
+
+        $feed = new Feed();
+
+        // Expect Exception
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage('The file is empty.');
+
+        // Actions
+        $filePath = vfsStream::url('root_dir/' . $testFeedFile);
+        $feed->sendFeed($filePath, 'user', 'password');
+    }
+
+    /** @test */
+    public function it_get_exception_when_ftp_login_fails()
+    {
+        // Set
+        $testFeedFile = 'test-feed-file.txt';
+
+        vfsStreamWrapper::register();
+        vfsStreamWrapper::setRoot(new vfsStreamDirectory('root_dir'));
+        vfsStream::newFile($testFeedFile)
+            ->at(vfsStreamWrapper::getRoot())
+            ->withContent('teste');
+
+        $feed = new Feed();
+
+        // Expect Exception
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage('Failed to login to sFTP');
+
+        // Actions
+        $filePath = vfsStream::url('root_dir/' . $testFeedFile);
+        $feed->sendFeed($filePath, 'user', 'password');
+    }
 }


### PR DESCRIPTION
This avoid to send empty files to Bazaarvoice.
Sometimes could be a problem sending a lot of files that could be empty.

So this way we can avoid this behavior.